### PR TITLE
Introduce drag-and-drop functionality for tabs using `@dnd-kit`.

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,24 +4,16 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="61a213b0-6f1e-4050-842c-2c04db9f0e38" name="Changes" comment="Initial Commit">
-      <change afterPath="$PROJECT_DIR$/public/icons/add_active.svg" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/components/components/Container.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/components/components/SmallRoundButton.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/components/components/TabButton.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/components/components/TabHoverActions.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/components/components/ui/DottedLines.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/components/data/index.ts" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/components/layout/MainLayout.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/stores/useAppStore.ts" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/types/index.ts" afterDir="false" />
+    <list default="true" id="61a213b0-6f1e-4050-842c-2c04db9f0e38" name="Changes" comment="Implement tab navigation structure and initial UI components&#10;&#10;- Add core `Container` component for tab layout.&#10;- Introduce `TabButton` and `TabHoverActions` for interactive tab behavior.&#10;- Create utility components: `DottedLines` and `SmallRoundButton`.&#10;- Add `useAppStore` for state management using Zustand.&#10;- Set up `PAGES` data and associated `Page` type definition.&#10;- Update `tsconfig.json` paths for organized imports.&#10;- Include dependencies: `zustand`, `class-variance-authority`, `clsx`, and more.">
+      <change afterPath="$PROJECT_DIR$/src/components/components/SortableTab.tsx" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/hooks/useDraggableTabs.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pnpm-lock.yaml" beforeDir="false" afterPath="$PROJECT_DIR$/pnpm-lock.yaml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/globals.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/globals.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/layout.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/layout.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/page.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tsconfig.json" beforeDir="false" afterPath="$PROJECT_DIR$/tsconfig.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/components/Container.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/components/Container.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/components/TabButton.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/components/TabButton.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/data/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/data/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/stores/useAppStore.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/stores/useAppStore.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -32,6 +24,11 @@
     <execution />
   </component>
   <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="master" />
+      </map>
+    </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
   <component name="GithubDefaultAccount">
@@ -52,7 +49,7 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "master",
+    "git-widget-placeholder": "feature/drag-to-reorder",
     "js.debugger.nextJs.config.created.client": "true",
     "js.debugger.nextJs.config.created.server": "true",
     "js.linters.configure.manually.selectedeslint": "true",
@@ -116,7 +113,7 @@
       <workItem from="1756849222499" duration="309000" />
       <workItem from="1756849536737" duration="13000" />
       <workItem from="1756849565924" duration="47000" />
-      <workItem from="1756849616589" duration="18824000" />
+      <workItem from="1756849616589" duration="26758000" />
     </task>
     <task id="LOCAL-00001" summary="Remove unnecessary `.idea` configuration files and `package-lock.json`.">
       <option name="closed" value="true" />
@@ -134,7 +131,15 @@
       <option name="project" value="LOCAL" />
       <updated>1756849707364</updated>
     </task>
-    <option name="localTasksCounter" value="3" />
+    <task id="LOCAL-00003" summary="Implement tab navigation structure and initial UI components&#10;&#10;- Add core `Container` component for tab layout.&#10;- Introduce `TabButton` and `TabHoverActions` for interactive tab behavior.&#10;- Create utility components: `DottedLines` and `SmallRoundButton`.&#10;- Add `useAppStore` for state management using Zustand.&#10;- Set up `PAGES` data and associated `Page` type definition.&#10;- Update `tsconfig.json` paths for organized imports.&#10;- Include dependencies: `zustand`, `class-variance-authority`, `clsx`, and more.">
+      <option name="closed" value="true" />
+      <created>1756869001580</created>
+      <option name="number" value="00003" />
+      <option name="presentableId" value="LOCAL-00003" />
+      <option name="project" value="LOCAL" />
+      <updated>1756869001580</updated>
+    </task>
+    <option name="localTasksCounter" value="4" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -145,7 +150,19 @@
       <map>
         <entry key="MAIN">
           <value>
-            <State />
+            <State>
+              <option name="FILTERS">
+                <map>
+                  <entry key="branch">
+                    <value>
+                      <list>
+                        <option value="origin/master" />
+                      </list>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </State>
           </value>
         </entry>
       </map>
@@ -154,7 +171,9 @@
   <component name="VcsManagerConfiguration">
     <MESSAGE value="Remove unnecessary `.idea` configuration files and `package-lock.json`." />
     <MESSAGE value="Initial Commit" />
-    <option name="LAST_COMMIT_MESSAGE" value="Initial Commit" />
+    <MESSAGE value="Add new icons, components, and utilities for improved UI functionality" />
+    <MESSAGE value="Implement tab navigation structure and initial UI components&#10;&#10;- Add core `Container` component for tab layout.&#10;- Introduce `TabButton` and `TabHoverActions` for interactive tab behavior.&#10;- Create utility components: `DottedLines` and `SmallRoundButton`.&#10;- Add `useAppStore` for state management using Zustand.&#10;- Set up `PAGES` data and associated `Page` type definition.&#10;- Update `tsconfig.json` paths for organized imports.&#10;- Include dependencies: `zustand`, `class-variance-authority`, `clsx`, and more." />
+    <option name="LAST_COMMIT_MESSAGE" value="Implement tab navigation structure and initial UI components&#10;&#10;- Add core `Container` component for tab layout.&#10;- Introduce `TabButton` and `TabHoverActions` for interactive tab behavior.&#10;- Create utility components: `DottedLines` and `SmallRoundButton`.&#10;- Add `useAppStore` for state management using Zustand.&#10;- Set up `PAGES` data and associated `Page` type definition.&#10;- Update `tsconfig.json` paths for organized imports.&#10;- Include dependencies: `zustand`, `class-variance-authority`, `clsx`, and more." />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.542.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/modifiers':
+        specifier: ^9.0.0
+        version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.1.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -108,6 +120,34 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@9.0.0':
+    resolution: {integrity: sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
@@ -1951,6 +1991,38 @@ snapshots:
   '-@0.0.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
 
   '@emnapi/core@1.5.0':
     dependencies:

--- a/src/components/components/Container.tsx
+++ b/src/components/components/Container.tsx
@@ -2,40 +2,75 @@
 
 import React, { ReactElement } from 'react';
 
+import { DndContext, DragOverlay } from '@dnd-kit/core';
+
+import { restrictToHorizontalAxis } from '@dnd-kit/modifiers';
+import {
+  horizontalListSortingStrategy,
+  SortableContext,
+} from '@dnd-kit/sortable';
+
+import SortableTab from '@/components/components/SortableTab';
 import TabButton from '@/components/components/TabButton';
-import TabHoverActions from '@/components/components/TabHoverActions';
-import DottedLines from '@/components/components/ui/DottedLines';
-import { PAGES } from '@/components/data';
-import useAppStore from '@/stores/useAppStore';
+import { PAGES_BY_SLUG } from '@/components/data';
+import useDraggableTabs from '@/hooks/useDraggableTabs';
 import { Page } from '@/types';
 
 function Container(): ReactElement {
-  const { page, setPage } = useAppStore();
+  const {
+    page,
+    setPage,
+    tabsOrder,
+    activeSlug,
+    orderedPages,
+    sensors,
+    handleDragStart,
+    handleDragEnd,
+    handleDragCancel,
+  } = useDraggableTabs();
+
+  const overlayPage: Page | null = activeSlug
+    ? PAGES_BY_SLUG[activeSlug]
+    : null;
 
   return (
     <div className="w-full max-w-[1100px] h-[72px] bg-white shadow-md rounded-md px-5">
       <div className="w-auto h-full flex items-center relative overflow-hidden">
-        {PAGES.map(
-          ({ icon, slug, name }: Page): ReactElement => (
-            <div key={slug} className="group flex items-center">
-              <TabButton
-                onClick={() => {
-                  setPage(slug);
-                }}
-                variant={page === slug ? 'active' : 'default'}
-                icon={icon}
-                text={name}
+        <DndContext
+          sensors={sensors}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+          modifiers={[restrictToHorizontalAxis]}
+        >
+          <SortableContext
+            items={tabsOrder}
+            strategy={horizontalListSortingStrategy}
+          >
+            {orderedPages.map(p => (
+              <SortableTab
+                key={p.slug}
+                page={p}
+                isActive={page === p.slug}
+                onClick={() => setPage(p.slug)}
               />
+            ))}
+          </SortableContext>
 
-              {/* Hover inline controls between tab and divider */}
-              <TabHoverActions />
-
-              <div className="shrink-0 -ml-px">
-                <DottedLines />
+          <DragOverlay adjustScale={false} zIndex={50}>
+            {overlayPage ? (
+              <div className="group flex items-center">
+                <TabButton
+                  variant={page === overlayPage.slug ? 'active' : 'default'}
+                  icon={overlayPage.icon}
+                  text={overlayPage.name}
+                  blurOnMouseDown
+                />
               </div>
-            </div>
-          ),
-        )}
+            ) : null}
+          </DragOverlay>
+        </DndContext>
+
         <TabButton variant="active" icon="add" text="Add Page" />
       </div>
     </div>

--- a/src/components/components/SortableTab.tsx
+++ b/src/components/components/SortableTab.tsx
@@ -1,0 +1,68 @@
+import React, { ReactElement } from 'react';
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+import TabButton from '@/components/components/TabButton';
+import TabHoverActions from '@/components/components/TabHoverActions';
+import DottedLines from '@/components/components/ui/DottedLines';
+import { Page } from '@/types';
+
+function SortableTab({
+  page,
+  isActive,
+  onClick,
+}: {
+  page: Page;
+  isActive: boolean;
+  onClick: () => void;
+}): ReactElement {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: page.slug });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="group flex items-center"
+      {...attributes}
+      {...listeners}
+    >
+      {isDragging ? (
+        <>
+          <div className="h-9 px-2.5 inline-flex items-center gap-2 rounded-md border border-dashed border-neutral-300 text-transparent bg-transparent">
+            <span className="w-[20px] h-[20px] inline-block" aria-hidden />
+            <span className="select-none">{page.name}</span>
+          </div>
+          <DottedLines />
+        </>
+      ) : (
+        <>
+          <TabButton
+            onClick={onClick}
+            variant={isActive ? 'active' : 'default'}
+            icon={page.icon}
+            text={page.name}
+          />
+          <TabHoverActions />
+          <div className="shrink-0 -ml-px">
+            <DottedLines />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default SortableTab;

--- a/src/components/components/TabButton.tsx
+++ b/src/components/components/TabButton.tsx
@@ -31,12 +31,14 @@ function TabButton({
   icon,
   text,
   onClick,
+  blurOnMouseDown,
 }: {
   className?: string;
   variant: 'default' | 'active' | null | undefined;
   icon: string;
   text: string;
   onClick?: () => void;
+  blurOnMouseDown?: boolean;
 }): ReactElement {
   const iconColor = variant === 'active' ? '_active' : '';
   const showOptions = variant === 'active' && icon !== 'add';
@@ -48,6 +50,7 @@ function TabButton({
         tabButtonVariants({ variant: variant || 'default', className }),
       )}
       onClick={onClick}
+      onMouseDown={blurOnMouseDown ? e => e.currentTarget.blur() : undefined}
     >
       <Image
         src={`/icons/${icon}${iconColor}.svg`}

--- a/src/components/data/index.ts
+++ b/src/components/data/index.ts
@@ -23,4 +23,10 @@ const PAGES: Page[] = [
   },
 ];
 
-export { PAGES };
+const PAGES_SLUGS: string[] = PAGES.map(p => p.slug);
+
+const PAGES_BY_SLUG: Record<string, Page> = Object.fromEntries(
+  PAGES.map(p => [p.slug, p] as const),
+);
+
+export { PAGES, PAGES_SLUGS, PAGES_BY_SLUG };

--- a/src/hooks/useDraggableTabs.ts
+++ b/src/hooks/useDraggableTabs.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+
+import {
+  DragEndEvent,
+  DragStartEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { arrayMove } from '@dnd-kit/sortable';
+
+import { PAGES, PAGES_BY_SLUG } from '@/components/data';
+import useAppStore from '@/stores/useAppStore';
+import { Page } from '@/types';
+
+function useDraggableTabs() {
+  const { page, setPage, tabsOrder, setTabsOrder, beginDrag, endDrag } =
+    useAppStore();
+
+  // Initialize order from PAGES once (watch length only)
+  useEffect(() => {
+    if (!tabsOrder || tabsOrder.length === 0) {
+      setTabsOrder(PAGES.map(p => p.slug));
+    }
+  }, [tabsOrder?.length, setTabsOrder]);
+
+  const orderedPages: Page[] =
+    !tabsOrder || tabsOrder.length === 0
+      ? PAGES
+      : tabsOrder
+          .map(slug => PAGES_BY_SLUG[slug])
+          .filter((p): p is Page => Boolean(p));
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+  );
+
+  // Keep only slug; derive Page in the overlay
+  const [activeSlug, setActiveSlug] = useState<string | null>(null);
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const slug = String(event.active.id);
+    beginDrag(slug);
+    setActiveSlug(slug);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const oldIndex = tabsOrder.indexOf(String(active.id));
+      const newIndex = tabsOrder.indexOf(String(over.id));
+      if (oldIndex !== -1 && newIndex !== -1) {
+        setTabsOrder(arrayMove(tabsOrder, oldIndex, newIndex));
+      }
+    }
+    setActiveSlug(null);
+    endDrag();
+  };
+
+  const handleDragCancel = () => {
+    setActiveSlug(null);
+    endDrag();
+  };
+
+  return {
+    page,
+    setPage,
+    tabsOrder,
+    orderedPages,
+    sensors,
+    activeSlug,
+    handleDragStart,
+    handleDragEnd,
+    handleDragCancel,
+  };
+}
+
+export default useDraggableTabs;

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -2,14 +2,21 @@ import { create, StoreApi, UseBoundStore } from 'zustand';
 
 type AppState = {
   page: string;
+  tabsOrder: string[]; // slugs in render order
+  draggingSlug: string | null; // null when not dragging
 };
 
 type AppActions = {
   setPage: (page: string) => void;
+  setTabsOrder: (order: string[]) => void;
+  beginDrag: (slug: string) => void;
+  endDrag: () => void;
 };
 
 const initialState: AppState = {
   page: 'info',
+  tabsOrder: [],
+  draggingSlug: null,
 };
 
 const useAppStore: UseBoundStore<StoreApi<AppState & AppActions>> = create<
@@ -18,6 +25,12 @@ const useAppStore: UseBoundStore<StoreApi<AppState & AppActions>> = create<
   ...initialState,
   setPage: (setPage: string) =>
     set((state: AppState & AppActions) => ({ ...state, page: setPage })),
+  setTabsOrder: (order: string[]) =>
+    set((state: AppState & AppActions) => ({ ...state, tabsOrder: order })),
+  beginDrag: (slug: string) =>
+    set((state: AppState & AppActions) => ({ ...state, draggingSlug: slug })),
+  endDrag: () =>
+    set((state: AppState & AppActions) => ({ ...state, draggingSlug: null })),
 }));
 
 export default useAppStore;


### PR DESCRIPTION
- Implement `SortableTab` component for draggable tab elements.
- Create `useDraggableTabs` hook to handle tab reordering logic and state.
- Update `Container` to integrate draggable tabs with overlay support.
- Extend `useAppStore` for tab order and drag state management.
- Modify `TabButton` for better drag interactions.
- Add utility exports (`PAGES_SLUGS`, `PAGES_BY_SLUG`) in `data/index`.
- Install and configure `@dnd-kit` dependencies.