### PR TITLE
Simplify hover actions by replacing `group-focus-within` with `group-…

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,12 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="61a213b0-6f1e-4050-842c-2c04db9f0e38" name="Changes" comment="Add horizontal scroll functionality with dynamic buttons for Containers">
+    <list default="true" id="61a213b0-6f1e-4050-842c-2c04db9f0e38" name="Changes" comment="Add horizontal scroll and dynamic button behavior for containers and improve the fade-in animation for TabButton.">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/globals.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/globals.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/components/components/TabButton.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/components/TabButton.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/components/Container.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/components/Container.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/components/SmallRoundButton.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/components/SmallRoundButton.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/components/SortableTab.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/components/SortableTab.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/components/TabHoverActions.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/components/TabHoverActions.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -20,7 +22,7 @@
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
       <map>
-        <entry key="$PROJECT_DIR$" value="feature/context-menu" />
+        <entry key="$PROJECT_DIR$" value="feature/add-new-tab" />
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
@@ -43,7 +45,7 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/add-new-tab",
+    "git-widget-placeholder": "fix/hover-interaction",
     "js.debugger.nextJs.config.created.client": "true",
     "js.debugger.nextJs.config.created.server": "true",
     "js.linters.configure.manually.selectedeslint": "true",
@@ -189,7 +191,15 @@
       <option name="project" value="LOCAL" />
       <updated>1756902454899</updated>
     </task>
-    <option name="localTasksCounter" value="9" />
+    <task id="LOCAL-00009" summary="Add horizontal scroll and dynamic button behavior for containers and improve the fade-in animation for TabButton.">
+      <option name="closed" value="true" />
+      <created>1756903923729</created>
+      <option name="number" value="00009" />
+      <option name="presentableId" value="LOCAL-00009" />
+      <option name="project" value="LOCAL" />
+      <updated>1756903923729</updated>
+    </task>
+    <option name="localTasksCounter" value="10" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -229,7 +239,8 @@
     <MESSAGE value="Refactor `TabButton` to include context menu; remove unused `blurOnMouseDown` prop." />
     <MESSAGE value="&quot;Add dynamic tab creation and insertion functionality with hover actions; refactor tab-related components for enhanced usability.&quot;" />
     <MESSAGE value="Add horizontal scroll functionality with dynamic buttons for Containers" />
-    <option name="LAST_COMMIT_MESSAGE" value="Add horizontal scroll functionality with dynamic buttons for Containers" />
+    <MESSAGE value="Add horizontal scroll and dynamic button behavior for containers and improve the fade-in animation for TabButton." />
+    <option name="LAST_COMMIT_MESSAGE" value="Add horizontal scroll and dynamic button behavior for containers and improve the fade-in animation for TabButton." />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/src/components/components/Container.tsx
+++ b/src/components/components/Container.tsx
@@ -13,7 +13,6 @@ import {
 import HorizontalScrollButtons from '@/components/components/HorizontalScrollButtons';
 import SortableTab from '@/components/components/SortableTab';
 import TabButton from '@/components/components/TabButton';
-import TabHoverActions from '@/components/components/TabHoverActions';
 import useDraggableTabs from '@/hooks/useDraggableTabs';
 import useHorizontalScrollControls from '@/hooks/useHorizontalScrollControls';
 import useAppStore from '@/stores/useAppStore';
@@ -67,9 +66,6 @@ function Container(): ReactElement {
             items={tabsOrder}
             strategy={horizontalListSortingStrategy}
           >
-            {/* insertion slot before first tab */}
-            <TabHoverActions onInsert={() => addPageAt(0)} />
-
             {orderedPages.map((p, i) => (
               <SortableTab
                 key={p.slug}

--- a/src/components/components/SmallRoundButton.tsx
+++ b/src/components/components/SmallRoundButton.tsx
@@ -7,7 +7,7 @@ function SmallRoundButton({ onClick }: { onClick?: () => void }): ReactElement {
     <button
       type="button"
       onClick={onClick}
-      className="w-5 h-5 flex items-center cursor-pointer justify-center rounded-full bg-background text-foreground shadow-md border border-tab-border hover:bg-tab-button-background/15 transition-colors duration-150"
+      className="w-5 h-5 flex items-center cursor-pointer justify-center rounded-full bg-background text-foreground shadow-md border border-tab-border hover:bg-tab-button-background/15 transition-colors duration-150 focus:outline-none focus-visible:border-[#2F72E2]"
     >
       <Image src={`/icons/add.svg`} alt={'add'} width={14} height={14} />
     </button>

--- a/src/components/components/SortableTab.tsx
+++ b/src/components/components/SortableTab.tsx
@@ -37,7 +37,7 @@ function SortableTab({
     <div
       ref={setNodeRef}
       style={style}
-      className="group flex items-center shrink-0"
+      className="group flex items-center shrink-0 focus:outline-none focus-visible:border-[#2F72E2]"
       {...attributes}
       {...listeners}
     >

--- a/src/components/components/TabHoverActions.tsx
+++ b/src/components/components/TabHoverActions.tsx
@@ -13,7 +13,7 @@ function TabHoverActions({
       className="
         flex items-center
         w-0 transition-[width] duration-200 ease-out
-        group-hover:w-[40px] group-focus-within:w-[40px]
+        group-hover:w-[40px] group-has-[:focus-visible]:w-[40px]
       "
       aria-hidden="true"
     >
@@ -23,7 +23,7 @@ function TabHoverActions({
           opacity-0 pointer-events-none
           transition-opacity duration-150 ease-out
           group-hover:opacity-100 group-hover:pointer-events-auto
-          group-focus-within:opacity-100 group-focus-within:pointer-events-auto
+          group-has-[:focus-visible]:opacity-100 group-has-[:focus-visible]:pointer-events-auto
         "
       >
         <div className="shrink-0">
@@ -34,7 +34,7 @@ function TabHoverActions({
             inline-flex items-center justify-center
             w-5 h-5 shrink-0
             scale-90 transition-transform duration-200 ease-out
-            group-hover:scale-100 group-focus-within:scale-100
+            group-hover:scale-100 group-has-[:focus-visible]:scale-100
           "
         >
           <SmallRoundButton onClick={onInsert} />


### PR DESCRIPTION
…has-[:focus-visible]`, remove unused `TabHoverActions` in `Container`, and improve focus styles for buttons and tabs.