### PR TITLE
Add "Set first page" feature with `useTabContextActions` integration

### DIFF
--- a/src/components/components/Container.tsx
+++ b/src/components/components/Container.tsx
@@ -73,6 +73,7 @@ function Container(): ReactElement {
                 isActive={page === p.slug}
                 onClick={() => setPage(p.slug)}
                 onInsertAfter={() => addPageAt(i + 1)}
+                isFirstPage={i === 0}
               />
             ))}
           </SortableContext>

--- a/src/components/components/SortableTab.tsx
+++ b/src/components/components/SortableTab.tsx
@@ -13,11 +13,13 @@ function SortableTab({
   isActive,
   onClick,
   onInsertAfter,
+  isFirstPage,
 }: {
   page: Page;
   isActive: boolean;
   onClick: () => void;
   onInsertAfter?: () => void;
+  isFirstPage?: boolean;
 }): ReactElement {
   const {
     attributes,
@@ -57,6 +59,8 @@ function SortableTab({
             variant={isActive ? 'active' : 'default'}
             icon={page.icon}
             text={page.name}
+            slug={page.slug}
+            isFirstPage={isFirstPage}
           />
           <TabHoverActions onInsert={onInsertAfter} />
           <div className="shrink-0 -ml-px">

--- a/src/components/components/TabButton.tsx
+++ b/src/components/components/TabButton.tsx
@@ -35,16 +35,20 @@ function TabButton({
   variant,
   icon,
   text,
+  slug,
   onClick,
+  isFirstPage,
 }: {
   className?: string;
   variant: 'default' | 'active' | null | undefined;
   icon: string;
   text: string;
+  slug?: string;
   onClick?: () => void;
+  isFirstPage?: boolean;
 }): ReactElement {
   const isActive = variant === 'active';
-  const showOptions = isActive && icon !== 'add';
+  const showOptions = isActive && icon !== 'add' && !isFirstPage;
 
   return (
     <ContextMenu>
@@ -104,7 +108,7 @@ function TabButton({
           </span>
         </button>
       </ContextMenuTrigger>
-      <TabContextMenu />
+      {slug ? <TabContextMenu slug={slug} /> : null}
     </ContextMenu>
   );
 }

--- a/src/components/components/TabContextMenu.tsx
+++ b/src/components/components/TabContextMenu.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 
 import Image from 'next/image';
 
+import useTabContextActions from '@/hooks/useTabContextActions';
 import {
   ContextMenuContent,
   ContextMenuItem,
@@ -9,7 +10,9 @@ import {
   ContextMenuSeparator,
 } from '@/shadcn/components/ui/context-menu';
 
-function TabContextMenu(): ReactElement {
+function TabContextMenu({ slug }: { slug: string }): ReactElement {
+  const { setFirstPage } = useTabContextActions();
+
   return (
     <ContextMenuContent className="w-56 border-0">
       {/* Header */}
@@ -17,7 +20,7 @@ function TabContextMenu(): ReactElement {
 
       <ContextMenuSeparator />
 
-      <ContextMenuItem>
+      <ContextMenuItem onClick={() => setFirstPage(slug)}>
         <Image src="/icons/flag.svg" alt="flag" width={16} height={16} />
         <span>Set first page</span>
       </ContextMenuItem>

--- a/src/hooks/useTabContextActions.ts
+++ b/src/hooks/useTabContextActions.ts
@@ -1,0 +1,19 @@
+import { PAGES } from '@/components/data';
+import useAppStore from '@/stores/useAppStore';
+
+function useTabContextActions() {
+  const { tabsOrder, setTabsOrder } = useAppStore();
+
+  const setFirstPage = (slug: string) => {
+    const currentOrder =
+      tabsOrder && tabsOrder.length > 0 ? tabsOrder : PAGES.map(p => p.slug);
+
+    const rest = currentOrder.filter(s => s !== slug);
+    const nextOrder = [slug, ...rest];
+    setTabsOrder(nextOrder);
+  };
+
+  return { setFirstPage };
+}
+
+export default useTabContextActions;


### PR DESCRIPTION
- Introduced `useTabContextActions` hook for tab order manipulation.
- Added "Set first page" action in `TabContextMenu` with updated TabButton props.
- Enhanced TabButton and SortableTab to support `isFirstPage` handling.